### PR TITLE
Add TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "0.12.4"
+sudo: required
+before_install:
+  - npm install -g grunt-cli bower
+  - sudo apt-get install nsis
+script:
+  - grunt clean:releases
+  - grunt build
+  - grunt compress


### PR DESCRIPTION
I tried to pull down the codebase and use the commands given in the readme.md to build and use the project.
They didn't work due an inability to resolve a 3rd party nodejs dependency due to a missing comma. This is pretty annoying.
Adding a travis.yml file will build the project on each commit and let us know that the project can successfully be compiled. 